### PR TITLE
updated to save new portfolio after rebalance/panic sell

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -158,10 +158,9 @@ class PortfoliosController < ApplicationController
 
       else
         unless coin.nil?
-          # calculates each position value in both btc and usdt
-          # position_value_btc = position[:free].to_f * coin.price_btc
+
           position_value_usdt = position[:free].to_f * coin.price_usdt
-          # calculates the pct difference between target and current allocations
+
           current_pct = (position_value_usdt / @portfolio.current_value_usdt).round(2)
           target_pct = @allocations.find { |a| a[:coin_id] == coin.id }.allocation_pct
           rebalance_pct = target_pct - current_pct
@@ -177,7 +176,7 @@ class PortfoliosController < ApplicationController
       end
     end
     execute_orders
-    #create_positions
+    create_positions
   end
 
 
@@ -248,7 +247,7 @@ class PortfoliosController < ApplicationController
       end
     end
     execute_orders
-    #create_positions
+    create_positions
   end
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,7 @@ lots = {
   LTC: 0.01,
   EOS: 1,
   ADA: 1,
-  USDT: 10,
+  USDT: 0.000001,
   TRX: 1,
   XLM: 1,
   ZEC: 0.001


### PR DESCRIPTION
- amended the USDT min unit (lot) size to be based in btc amount which is what the calculation is based on for in the sell down of USDt positions to btc.

- calls the create_positions method after rebalance / panic sell to save changes to the portfolio