### PR TITLE
added trade confirmations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
 
-
 group :development do
   gem 'web-console', '>= 3.3.0'
 end

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,3 +1,6 @@
+
+
+
 <div class="container">
   <h1>Portfolio<small> for <%= current_user.email %></small></h1>
   <div class="row">
@@ -28,8 +31,9 @@
     <div class="col-6 text-right">
 
       <h2>Total value <%= number_to_currency(@portfolio.current_value_btc.to_f * price_btc) %></h2>
-
+      <h2>BCGI Index: <%= @index %></h2>
     </div>
+
   </div>
   <div class="row">
     <div class="col-lg-7">


### PR DESCRIPTION
- still need to add display for this method
- It does not work well in testing since there are no real trades.  It only returns the trade details for the last 'real' trade executed.  This allows a confirmation for each trade as the process iterates through the list of order executions.  In test mode it just displays the last historical trade for the coin.  This will break the code if there were no previous trades done by returning nil. Uncomment the code when testing live.  This also brings up the issue of when no trade is done in the coin in live testing.  I still have to test for and fix this scenario.
- Refactored some code for checking bitcoin vs USDT into separate method