### PR TITLE
Seperate buy and sells

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,6 @@ class OrdersController < ApplicationController
   skip_before_action :authenticate_user!
 
   def create
-    Binance::Api::Order.create!(quantity: '100.0', side: 'BUY', symbol: 'XLMETH', type: 'MARKET')
   end
 
   def index

--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -127,6 +127,7 @@ class PortfoliosController < ApplicationController
     else
       required_amount = (number_of_btc / min_trade_unit).round * min_trade_unit
     end
+
     return required_amount
   end
 
@@ -153,7 +154,6 @@ class PortfoliosController < ApplicationController
   def rebalance_positions
     @rebalance_hash = {}
     @coins_arr = []
-
     price_btc = Coin.find_by(symbol: 'BTC').price_usdt
     read_portfolio_info
 
@@ -174,8 +174,7 @@ class PortfoliosController < ApplicationController
             quantity: quantity,
             side: 'BUY',
             symbol: 'BTCUSDT',
-            type: 'MARKET',
-            test: true
+            type: 'MARKET'
           )
 
         end
@@ -241,17 +240,19 @@ class PortfoliosController < ApplicationController
         || coinhash[:amount] < order_lot_size(coinhash)
 
         quantity = order_lot_size(coinhash)
+          ## should be sell order but code trying to set buy order
+    raise
 
         Binance::Api::Order.create!(
           quantity: quantity,
           side: side,
           symbol: "#{coinhash[:name]}BTC",
-          type: 'MARKET',
-          test: true
+          type: 'MARKET'
+          # test: true
         )
         # doesnot work for test trade as it returns {} and has nil error
         # uncomment below line in real testing
-        # get_trade_confirmation(coinhash[:name])
+        get_trade_confirmation(coinhash[:name])
 
       end
     end
@@ -278,8 +279,7 @@ class PortfoliosController < ApplicationController
             quantity: quantity,
             side: 'SELL',
             symbol: 'BTCUSDT',
-            type: 'MARKET',
-            test: true
+            type: 'MARKET'
           )
         end
 

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -40,7 +40,11 @@
       <table class="table table-responsive w-auto table-dark">
         <thead>
           <tr>
-            <th scope="col">#</th>
+            <th scope="col">
+              <%= link_to create_positions_path do %>
+                <i class="fas fa-sync-alt"></i>
+              <% end %>
+            </th>
             <th scope="col">Coin</th>
             <th scope="col">Amount</th>
             <th scope="col">Value (BTC)</th>
@@ -58,21 +62,28 @@
                 <td><%= sprintf('%.6f', position.quantity) %></td>
                 <td><%= sprintf('%.6f', (position.quantity * coin.price_btc)) %></td>
                 <td><%= sprintf('%.2f', (position.quantity * coin.price_usdt)) %></td>
-                <td><%= sprintf('%.1f', ((position.quantity * coin.price_usdt)/(@portfolio.current_value_btc * price_btc))*100) %>%</td>
-
+                <td><%= sprintf('%.1f', ((position.quantity * coin.price_usdt)/@usdt_total)*100) %>%</td>
                 <td><%= @allocations.find {|a| a[:coin_id] == coin.id}.allocation_pct %>%</td>
               </tr>
             <% end %>
           </tbody>
           <tfoot>
             <tr>
-              <td></td>
-              <td></td>
-              <td></td>
-              <td></td>
-              <td></td>
-              <td></td>
-              <td></td>
+              <td></td> <!-- image -->
+              <td></td> <!-- name -->
+              <td></td> <!-- quantity -->
+              <td><!-- total btc -->
+                <%= @btc_total %>
+              </td>
+              <td> <!-- total usdt -->
+                $<%= @usdt_total %>
+              </td>
+              <td> <!-- total % -->
+                <%= @percentage %>%
+              </td>
+              <td> <!-- alloc % -->
+
+              </td>
             </tr>
           </tfoot>
         </table>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,6 +1,3 @@
-
-
-
 <div class="container">
   <div class="dashboard">
     <div class="row">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2019_06_05_095834) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.float "price_btc"
-    t.decimal "lot_size"
+    t.float "lot_size"
     t.string "color"
     t.string "image"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,18 +31,32 @@ User.create(
 puts 'Creating coins'
 
 coins = ['Bitcoin','Ethereum','Ripple','Bitcoin-Cash','Litecoin','EOS','Cardano','Tether','Tron','Stellar','Zcash']
+# lots = {
+#   BTC: 0.000001,
+#   ETH: 0.001,
+#   XRP: 1,
+#   BCHABC: 0.001,
+#   LTC: 0.01,
+#   EOS: 1,
+#   ADA: 1,
+#   USDT: 0.000001,
+#   TRX: 1,
+#   XLM: 1,
+#   ZEC: 0.001
+# }
+
 lots = {
-  BTC: 0.000001,
-  ETH: 0.001,
+  BTC: 1000000,
+  ETH: 1000,
   XRP: 1,
-  BCHABC: 0.001,
-  LTC: 0.01,
+  BCHABC: 1000,
+  LTC: 100,
   EOS: 1,
   ADA: 1,
-  USDT: 0.000001,
+  USDT: 1000000,
   TRX: 1,
   XLM: 1,
-  ZEC: 0.001
+  ZEC: 1000
 }
 
 colors = {


### PR DESCRIPTION
Seperated buy and sell orders into different coinhashes, so they can be executed seperately.

Added total columns to show page table

Changed lot sizes to attempt to fix required amounts generated for sell orders: 
0.01 => 100, 0.001 => 1000 etc..
`required_amount = (coinhash[:amount] * @coin_instance[:lot_size]).round / @coin_instance[:lot_size]`