### PR TITLE
added USDT price

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -99,10 +99,14 @@ coins.each do |coin|
     btc_data = JSON.parse(btc_json)
   end
 
+  bitcoin_url = "https://www.binance.com/api/v3/ticker/price?symbol=BTCUSDT"
+  bitcoin_json = open(bitcoin_url).read
+  bitcoin_data = JSON.parse(bitcoin_json)
+
 
   if coin == 'Tether'
     price_usdt = 1
-    price_btc = 0
+    price_btc = 1 / bitcoin_data['price'].to_f
   elsif coin == 'Bitcoin'
     price_usdt = usdt_data['price']
     price_btc = 1


### PR DESCRIPTION
- USDT price added which resolves issue of USDT portfolio value not showing
- amended BTC offer side reference price to the 3rd price in binance order book.  This is used to calculate the number of BTC to buy given the amount of USDT.  It helps to overcome the issue of movement in BTC price in a fast market.