### PR TITLE
Cleanup trade history dashboard

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -108,11 +108,11 @@ def portfolio_params
 end
 
 def create_allocations
-  if params[:crypto].values.map(&:to_i).sum != 100
+  if params[:allocations][:crypto].values.map(&:to_i).sum != 100
     flash[:failure] = "Allocation must total 100% !"
     # redirect_to new_portfolio_allocation_path(@portfolio)
   else
-    params[:crypto].each do |coin, percentage|
+    params[:allocations][:crypto].each do |coin, percentage|
       @allocation = Allocation.new
       @allocation.portfolio_id = @portfolio.id
       @allocation.coin_id = Coin.find_by(name: coin).id

--- a/app/javascript/components/button_confirms.js
+++ b/app/javascript/components/button_confirms.js
@@ -31,7 +31,7 @@ function rebalanceConf(){
         dialog.init(function(){
             setTimeout(function(){
                 dialog.find('.bootbox-body').html('I was loaded after the dialog was shown!');
-            }, 15000);
+            }, 60000);
         });
         }
       }
@@ -70,7 +70,7 @@ function sellConf(){
         dialog.init(function(){
             setTimeout(function(){
                 dialog.find('.bootbox-body').html('I was loaded after the dialog was shown!');
-            }, 15000);
+            }, 60000);
         });
         }
       }

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -41,6 +41,8 @@ class Portfolio < ApplicationRecord
     self.update_positions
     @coins_arr = []
     @confirmations_arr = []
+    @flag = 'rebalance'
+    @transaction_id = SecureRandom.uuid
 
     # fetch lastest price for btc
     @price_btc = lastest_btc_price
@@ -99,7 +101,6 @@ class Portfolio < ApplicationRecord
 
       end
     end
-    @flag = 'rebalance'
     execute_orders
   end
 
@@ -108,6 +109,8 @@ class Portfolio < ApplicationRecord
     @confirmations_arr = []
     read_portfolio_info
     @price_btc = lastest_btc_price
+    @flag = 'panic_sell'
+    @transaction_id = SecureRandom.uuid
 
     @positions.each do |position|
       coin = Coin.find_by(symbol: position[:asset])
@@ -143,7 +146,6 @@ class Portfolio < ApplicationRecord
         # byebug
       end
     end
-    @flag = 'panic_sell'
     execute_orders
   end
 
@@ -218,7 +220,6 @@ class Portfolio < ApplicationRecord
   end
 
   def get_trade_confirmation(confirmation)
-
     unless confirmation == []
       puts @confirmations_arr
       # byebug
@@ -250,7 +251,9 @@ class Portfolio < ApplicationRecord
           portfolio_id: self.id,
           base_coin_id: base_coin.id,
           target_coin_id: target_coin.id,
-          transact_time: order[:transactTime]
+          transact_time: order[:transactTime],
+          description: @flag.capitalize,
+          transaction_id: @transaction_id
         )
         o.save
         # byebug

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,76 +1,75 @@
-<h1>Orders</h1>
+<div class="header container-fluid">
+  <div class="row">
+    <div class="col">
+      <div class="price-container text-center justify-content-center">
+        <h5>Transactions</h5>
+      </div>
+    </div>
+  </div>
+<div class="container">
+  <div class="card-container" id="target">
+    <% all_orders = Order.all %>
+    <% @transactions = all_orders.sort_by(&:transact_time).group_by(&:transaction_id) %>
+    <% @transactions.each_with_index do |transaction, index| %>
+      <div class="card-product" data-toggle="collapse" data-parent="#target" href="#collapse<%= index + 1 %>">
+        <% if transaction.last.first[:description] == 'Rebalance' %>
+          <% color = 'green' %>
+        <% else %>
+          <% color = 'red' %>
+        <% end %>
+        <div class="position-card" style="border-left: 15px solid <%= color %>;">
+          <span>
+            <%= Time.at(transaction.last.first[:transact_time].to_i / 1000).to_datetime.strftime(" %b %d, %Y %l:%M %p") %>
+          </span>
+          <p><%= transaction.last.first[:description] %></p>
+        </div>
+      </div>
+      <div id="collapse<%= index+1 %>" class="panel-collapse collapse">
+        <div>
+          <div class="card-container">
+            <div class="position-card" style="border-left: 15px solid <%= color %>;">
+              <div class="card-product p-3">
+                <div class="row">
+                  <div class="col justify-between">
+                    <table class="table table-borderless">
+                      <thead>
+                        <tr>
+                          <th scope="col">Symbol</th>
+                          <th scope="col">Side</th>
+                          <th scope="col">Quantity</th>
+                          <th scope="col">Base Coin</th>
+                          <th scope="col">Price</th>
+                          <th scope="col">Target Coin</th>
+                          <th scope="col">Commission</th>
+                          <th scope="col">Commission Asset</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <% transaction.last.each do |order| %>
+                            <% @coin_base = Coin.find(order[:base_coin_id]).symbol %>
+                            <% @coin_target = Coin.find(order[:target_coin_id]).symbol %>
+                                <tr>
+                                  <td><%= "#{@coin_base}#{@coin_target}" %></td>
+                                  <td><%= order[:side] %></td>
+                                  <td><%= "%f" % order[:quantity] %></td>
+                                  <td><%= @coin_base %></td>
+                                  <td><%= "%f" % order[:price] %></td>
+                                  <td><%= @coin_target %></td>
+                                  <td><%= "%f" % order[:commission] %></td>
+                                  <td><%= order[:commission_asset] %></td>
 
+                                </tr>
 
-<table class="table table-dark">
-  <thead>
-    <tr>
-      <th scope="col">Binance ID</th>
-      <th scope="col">Transaction Time</th>
-      <th scope="col">Status</th>
-      <th scope="col">Symbol</th>
-      <th scope="col">Side</th>
-      <th scope="col">Quantity</th>
-      <th scope="col">Base Coin</th>
-      <th scope="col">Price</th>
-      <th scope="col">Target Coin</th>
-      <th scope="col">Type</th>
-      <th scope="col">Commission</th>
-      <th scope="col">Commission Asset</th>
-    </tr>
-  </thead>
-  <tbody>
-      <% @orders.each do |trade| %>
-        <% @coin_base = Coin.find(trade[:base_coin_id]).symbol %>
-        <% @coin_target = Coin.find(trade[:target_coin_id]).symbol %>
-
-    <tr>
-      <td><%= trade[:binance_id] %></td>
-      <td><%= Time.at(trade[:transact_time].to_i / 1000).to_datetime %></td>
-      <td><%= trade[:status] %></td>
-      <td><%= "#{@coin_base}#{@coin_target}" %></td>
-      <td><%= trade[:side] %></td>
-      <td><%= "%f" % trade[:quantity] %></td>
-      <td><%= @coin_base %></td>
-      <td><%= "%f" % trade[:price] %></td>
-      <td><%= @coin_target %></td>
-      <td><%= trade[:order_type] %></td>
-      <td><%= "%f" % trade[:commission] %></td>
-      <td><%= trade[:commission_asset] %></td>
-
-    </tr>
+                        <% end %>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     <% end %>
-  </tbody>
-</table>
-
-      <!--# need to add trade time to schema
-      # need to convert coin_id to coin symbol
-      # need to add full ticker symbol
-      # sort orders by time done
-      # allow filter function to find_by where etc.
-      # do not display exponential number formats-->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  </div>
+</div>

--- a/db/migrate/20190612015433_add_columns_to_orders.rb
+++ b/db/migrate/20190612015433_add_columns_to_orders.rb
@@ -1,0 +1,6 @@
+class AddColumnsToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :description, :string
+    add_column :orders, :transaction_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_11_125310) do
+ActiveRecord::Schema.define(version: 2019_06_12_015433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2019_06_11_125310) do
     t.bigint "portfolio_id"
     t.string "commission_asset"
     t.string "transact_time"
+    t.string "description"
+    t.string "transaction_id"
     t.index ["base_coin_id"], name: "index_orders_on_base_coin_id"
     t.index ["portfolio_id"], name: "index_orders_on_portfolio_id"
     t.index ["target_coin_id"], name: "index_orders_on_target_coin_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ require 'json'
 
 puts 'Destroying db contents'
 # Delete records
+Order.destroy_all
 Position.destroy_all
 Allocation.destroy_all
 Portfolio.destroy_all


### PR DESCRIPTION
- Added transaction_id and description columns to orders table
- Set description to either rebalance or panic_sell depending on the action
- Set all orders in the overall transaction to the same transaction_id which is a guid
- Created an orders index page with collapsible cards