### PR TITLE
set api keys as variables manually in each job

### DIFF
--- a/app/jobs/get_positions_job.rb
+++ b/app/jobs/get_positions_job.rb
@@ -4,9 +4,13 @@ require_relative '../models/portfolio'
 class GetPositionsJob < ApplicationJob
   queue_as :default
 
+
+
   def perform
     portfolios = Portfolio.all
     portfolios.each do |portfolio|
+      Binance::Api::Configuration.api_key = portfolio.user.api_key
+      Binance::Api::Configuration.secret_key = portfolio.user.secret_key
       portfolio.update_positions
     end
   end

--- a/app/jobs/rebalance_portfolio_job.rb
+++ b/app/jobs/rebalance_portfolio_job.rb
@@ -7,10 +7,12 @@ class RebalancePortfolioJob < ApplicationJob
 
   def perform
     # Do something later
+
     portfolios = Portfolio.all
     portfolios.each do |portfolio|
       next unless Date.today == portfolio.next_rebalance_dt
-
+      Binance::Api::Configuration.api_key = portfolio.user.api_key
+      Binance::Api::Configuration.secret_key = portfolio.user.secret_key
       portfolio.rebalance
       if portfolio.rebalance_freq == 'Daily'
         portfolio.next_rebalance_dt = portfolio.next_rebalance_dt.tomorrow


### PR DESCRIPTION
set as variables by pulling from the database for each iteration of portfolio jobs

otherwise scheduler cannot pull the keys from enviroment